### PR TITLE
Fixes #40

### DIFF
--- a/XPlatformMenus/XPlatformMenus.Droid/Fragments/Base/BaseFragment.cs
+++ b/XPlatformMenus/XPlatformMenus.Droid/Fragments/Base/BaseFragment.cs
@@ -46,7 +46,7 @@ namespace XPlatformMenus.Droid.Fragments
                         Resource.String.drawer_close            // "close drawer" description
                     );
                     _drawerToggle.DrawerOpened += (object sender, ActionBarDrawerEventArgs e) => ((MainActivity)Activity).HideSoftKeyboard();
-                    ((MainActivity)Activity).DrawerLayout.SetDrawerListener(_drawerToggle);
+                    ((MainActivity)Activity).DrawerLayout.AddDrawerListener(_drawerToggle);
                 }
             }
             return view;

--- a/XPlatformMenus/XPlatformMenus.Droid/Resources/layout/toolbar_actionbar.axml
+++ b/XPlatformMenus/XPlatformMenus.Droid/Resources/layout/toolbar_actionbar.axml
@@ -8,7 +8,6 @@
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
-        android:fitsSystemWindows="true"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"


### PR DESCRIPTION
The presence of two `android:fitsSystemWindows="true"` attributes in the `toolbar_actionbar.axml` layout causes the toolbar to appear incorrectly.

I've also updated the sample to use the `AddDrawerListener` replacement for the deprecated `SetDrawerListener` API.