### PR TITLE
[StarWarsSample] Remove error condition in iOS app

### DIFF
--- a/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
@@ -284,7 +284,5 @@
         <PropertyGroup>
             <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
         </PropertyGroup>
-        <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')"
-               Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets'))" />
     </Target>
 </Project>


### PR DESCRIPTION
With PackageReference restoring to a central location, this file will _never_ exist, making this error condition invalid. 

Fixes https://github.com/MvvmCross/MvvmCross-Samples/issues/119