### PR TITLE
StarWars Sample Upgrade

### DIFF
--- a/StarWarsSample/StarWarsSample.Core/AppStart.cs
+++ b/StarWarsSample/StarWarsSample.Core/AppStart.cs
@@ -6,17 +6,14 @@ namespace StarWarsSample.Core
 {
     public class AppStart : MvxAppStart
     {
-        private readonly IMvxNavigationService _mvxNavigationService;
-
         public AppStart(IMvxApplication app, IMvxNavigationService mvxNavigationService)
-            : base(app)
+            : base(app, mvxNavigationService)
         {
-            _mvxNavigationService = mvxNavigationService;
         }
 
-        protected override void Startup(object hint = null)
+        protected override void NavigateToFirstViewModel(object hint = null)
         {
-            _mvxNavigationService.Navigate<MainViewModel>();
+            NavigationService.Navigate<MainViewModel>();
         }
     }
 }

--- a/StarWarsSample/StarWarsSample.Core/Rest/Implementations/RestClient.cs
+++ b/StarWarsSample/StarWarsSample.Core/Rest/Implementations/RestClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using MvvmCross.Base;
+using MvvmCross.Logging;
 using StarWarsSample.Core.Rest.Interfaces;
 
 namespace StarWarsSample.Core.Rest.Implementations
@@ -10,10 +11,12 @@ namespace StarWarsSample.Core.Rest.Implementations
     public class RestClient : IRestClient
     {
         private readonly IMvxJsonConverter _jsonConverter;
+        private readonly IMvxLog _mvxLog;
 
-        public RestClient(IMvxJsonConverter jsonConverter)
+        public RestClient(IMvxJsonConverter jsonConverter, IMvxLog mvxLog)
         {
             _jsonConverter = jsonConverter;
+            _mvxLog = mvxLog;
         }
 
         public async Task<TResult> MakeApiCall<TResult>(string url, HttpMethod method, object data = null) where TResult : class
@@ -36,9 +39,9 @@ namespace StarWarsSample.Core.Rest.Implementations
                     {
                         response = await httpClient.SendAsync(request).ConfigureAwait(false);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        // log error
+                        _mvxLog.ErrorException("MakeApiCall failed", ex);
                     }
 
                     var stringSerialized = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/StarWarsSample/StarWarsSample.Core/StarWarsSample.Core.csproj
+++ b/StarWarsSample/StarWarsSample.Core/StarWarsSample.Core.csproj
@@ -20,8 +20,8 @@
     <Folder Include="Extensions\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Acr.UserDialogs" Version="7.0.1" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
-    <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
     <PackageReference Include="MvvmCross" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />

--- a/StarWarsSample/StarWarsSample.Core/StarWarsSample.Core.csproj
+++ b/StarWarsSample/StarWarsSample.Core/StarWarsSample.Core.csproj
@@ -22,10 +22,10 @@
   <ItemGroup>
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
     <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
-    <PackageReference Include="MvvmCross" Version="6.0.0" />
-    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.0.0" />
-    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.0.0" />
-    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.0.0" />
+    <PackageReference Include="MvvmCross" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.resx">

--- a/StarWarsSample/StarWarsSample.Droid/Resources/Resource.designer.cs
+++ b/StarWarsSample/StarWarsSample.Droid/Resources/Resource.designer.cs
@@ -4146,7 +4146,6 @@ namespace StarWarsSample.Droid
 			global::MvvmCross.Droid.Support.V7.RecyclerView.Resource.Styleable.RecyclerView_reverseLayout = global::StarWarsSample.Droid.Resource.Styleable.RecyclerView_reverseLayout;
 			global::MvvmCross.Droid.Support.V7.RecyclerView.Resource.Styleable.RecyclerView_spanCount = global::StarWarsSample.Droid.Resource.Styleable.RecyclerView_spanCount;
 			global::MvvmCross.Droid.Support.V7.RecyclerView.Resource.Styleable.RecyclerView_stackFromEnd = global::StarWarsSample.Droid.Resource.Styleable.RecyclerView_stackFromEnd;
-			global::Splat.Resource.String.library_name = global::StarWarsSample.Droid.Resource.String.library_name;
 		}
 		
 		public partial class Animation
@@ -7785,14 +7784,14 @@ namespace StarWarsSample.Droid
 			// aapt resource value: 0x7f0a002c
 			public const int drawer_open = 2131361836;
 			
-			// aapt resource value: 0x7f0a0028
-			public const int fab_scroll_shrink_grow_autohide_behavior = 2131361832;
+			// aapt resource value: 0x7f0a0027
+			public const int fab_scroll_shrink_grow_autohide_behavior = 2131361831;
 			
 			// aapt resource value: 0x7f0a002a
 			public const int hello = 2131361834;
 			
-			// aapt resource value: 0x7f0a0027
-			public const int library_name = 2131361831;
+			// aapt resource value: 0x7f0a0029
+			public const int library_name = 2131361833;
 			
 			// aapt resource value: 0x7f0a0021
 			public const int password_toggle_content_description = 2131361825;
@@ -7815,8 +7814,8 @@ namespace StarWarsSample.Droid
 			// aapt resource value: 0x7f0a0026
 			public const int status_bar_notification_info_overflow = 2131361830;
 			
-			// aapt resource value: 0x7f0a0029
-			public const int view_scroll_translation_autohide_behavior = 2131361833;
+			// aapt resource value: 0x7f0a0028
+			public const int view_scroll_translation_autohide_behavior = 2131361832;
 			
 			static String()
 			{

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -70,22 +70,22 @@
     <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
     <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
-    <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0" />
-    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3" />
-    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Annotations" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Compat" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Fragment" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Percent" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Transition" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3.1" />
+    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.0.3.1" />
+    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Annotations" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Compat" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Fragment" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Percent" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Transition" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Build.Download" Version="0.4.9" />
   </ItemGroup>
   <ItemGroup>

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -69,7 +69,6 @@
     <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
-    <PackageReference Include="Splat" Version="2.0.0" />
     <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
     <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3" />

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -86,7 +86,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.2.1" />
-    <PackageReference Include="Xamarin.Build.Download" Version="0.4.9" />
+    <PackageReference Include="Xamarin.Build.Download" Version="0.4.11" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -1,189 +1,189 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="..\packages\Xamarin.Build.Download.0.4.9\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.9\build\Xamarin.Build.Download.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{7A6574CB-A020-4BC5-82BA-BC8FB9022349}</ProjectGuid>
-        <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <OutputType>Library</OutputType>
-        <RootNamespace>StarWarsSample.Droid</RootNamespace>
-        <AssemblyName>StarWarsSample.Droid</AssemblyName>
-        <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-        <AndroidApplication>True</AndroidApplication>
-        <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-        <AndroidResgenClass>Resource</AndroidResgenClass>
-        <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-        <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-        <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-        <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-        <NuGetPackageImportStamp>
-        </NuGetPackageImportStamp>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug</OutputPath>
-        <DefineConstants>DEBUG;</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AndroidLinkMode>None</AndroidLinkMode>
-        <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-        <AndroidTlsProvider>btls</AndroidTlsProvider>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AndroidManagedSymbols>true</AndroidManagedSymbols>
-        <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="System" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Core" />
-        <Reference Include="Mono.Android" />
-        <Reference Include="Mono.Android.Export" />
-        <Reference Include="System.Net.Http" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
-        <PackageReference Include="OxyPlot.Xamarin.Android" Version="1.1.0-unstable0011" />
-        <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
-        <PackageReference Include="Acr.Support" Version="2.1.0" />
-        <PackageReference Include="Refractored.Controls.CircleImageView" Version="1.0.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="MvvmCross" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Droid.Support.Core.UI" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Droid.Support.Core.Utils" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Droid.Support.Design" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Droid.Support.Fragment" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Droid.Support.V7.RecyclerView" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Json" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Color" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.0.0" />
-        <PackageReference Include="Splat" Version="2.0.0" />
-        <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
-        <PackageReference Include="AndHUD" Version="1.2.0" />
-        <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0" />
-        <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3" />
-        <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.0.3" />
-        <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Annotations" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Compat" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Fragment" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Percent" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Transition" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.2" />
-        <PackageReference Include="Xamarin.Build.Download" Version="0.4.9" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Resources\Resource.designer.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="LinkerPleaseInclude.cs" />
-        <Compile Include="Setup.cs" />
-        <Compile Include="SplashScreen.cs" />
-        <Compile Include="Views\MainView.cs" />
-        <Compile Include="Views\PlanetsView.cs" />
-        <Compile Include="Views\MenuView.cs" />
-        <Compile Include="Views\BaseFragment.cs" />
-        <Compile Include="Extensions\MvxRecyclerViewExtensions.cs" />
-        <Compile Include="Controls\RecyclerViewOnScrollListener.cs" />
-        <Compile Include="Views\PlanetView.cs" />
-        <Compile Include="Controls\InfoView.cs" />
-        <Compile Include="Views\PeopleView.cs" />
-        <Compile Include="Views\StatusView.cs" />
-        <Compile Include="Views\PersonView.cs" />
-        <Compile Include="MvxBindings\SwipeRefreshLayoutIsRefreshingTargetBinding.cs" />
-        <Compile Include="TemplateSelectors\PlanetsTemplateSelector.cs" />
-        <Compile Include="MainApplication.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="Resources\AboutResources.txt" />
-        <None Include="Properties\AndroidManifest.xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <AndroidResource Include="Resources\layout\MenuView.axml" />
-        <AndroidResource Include="Resources\values\Strings.xml" />
-        <AndroidResource Include="Resources\layout\MainView.axml" />
-        <AndroidResource Include="Resources\layout\SplashScreen.axml" />
-        <AndroidResource Include="Resources\layout\toolbar_actionbar.axml" />
-        <AndroidResource Include="Resources\values\colors.xml" />
-        <AndroidResource Include="Resources\values\dimens.xml" />
-        <AndroidResource Include="Resources\values\styles.xml" />
-        <AndroidResource Include="Resources\values-v21\styles.xml" />
-        <AndroidResource Include="Resources\menu\navigation_drawer.axml" />
-        <AndroidResource Include="Resources\layout\navigation_header.axml" />
-        <AndroidResource Include="Resources\layout\PlanetsView.axml" />
-        <AndroidResource Include="Resources\layout\item_name.axml" />
-        <AndroidResource Include="Resources\layout\PlanetView.axml" />
-        <AndroidResource Include="Resources\layout\control_info_view.axml" />
-        <AndroidResource Include="Resources\anim\pulse_animation.xml" />
-        <AndroidResource Include="Resources\layout\PeopleView.axml" />
-        <AndroidResource Include="Resources\drawable-nodpi\Planet_Header.jpg" />
-        <AndroidResource Include="Resources\drawable-nodpi\Background.jpg" />
-        <AndroidResource Include="Resources\mipmap-hdpi\icon.png" />
-        <AndroidResource Include="Resources\mipmap-mdpi\icon.png" />
-        <AndroidResource Include="Resources\mipmap-xhdpi\icon.png" />
-        <AndroidResource Include="Resources\mipmap-xxhdpi\icon.png" />
-        <AndroidResource Include="Resources\mipmap-xxxhdpi\icon.png" />
-        <AndroidResource Include="Resources\drawable\another_option.xml" />
-        <AndroidResource Include="Resources\drawable\people.xml" />
-        <AndroidResource Include="Resources\drawable\planet.xml" />
-        <AndroidResource Include="Resources\layout\StatusView.axml" />
-        <AndroidResource Include="Resources\drawable-hdpi\screen.png" />
-        <AndroidResource Include="Resources\drawable-mdpi\screen.png" />
-        <AndroidResource Include="Resources\drawable-xhdpi\screen.png" />
-        <AndroidResource Include="Resources\drawable-xxhdpi\screen.png" />
-        <AndroidResource Include="Resources\drawable-xxxhdpi\screen.png" />
-        <AndroidResource Include="Resources\drawable-nodpi\menu_header_background.png" />
-        <AndroidResource Include="Resources\drawable-nodpi\People_Header.png" />
-        <AndroidResource Include="Resources\drawable-nodpi\profile.png" />
-        <AndroidResource Include="Resources\drawable\statistics.xml" />
-        <AndroidResource Include="Resources\layout\PersonView.axml" />
-        <AndroidResource Include="Resources\layout\item_name_white.axml" />
-    </ItemGroup>
-    <ItemGroup />
-    <ItemGroup>
-        <AndroidAsset Include="Assets\starwars.json" />
-        <AndroidAsset Include="Assets\imgs\img_0.png" />
-        <AndroidAsset Include="Assets\imgs\img_1.png" />
-        <AndroidAsset Include="Assets\imgs\char1.png" />
-        <AndroidAsset Include="Assets\imgs\char2.png" />
-        <AndroidAsset Include="Assets\imgs\weapon.png" />
-        <AndroidAsset Include="Assets\imgs\weapon2.png" />
-        <AndroidAsset Include="Assets\starwars2.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\StarWarsSample.Core\StarWarsSample.Core.csproj">
-            <Project>{C8D72805-91D3-48B5-8F5B-44B9263198B6}</Project>
-            <Name>StarWarsSample.Core</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-    <ProjectExtensions>
-      <MonoDevelop>
-        <Properties>
-          <Policies>
-            <TextStylePolicy TabWidth="4" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabsToSpaces="True" scope="application/android+xml" />
-            <XmlFormattingPolicy scope="application/android+xml">
-              <DefaultFormat AttributesInNewLine="True" AlignAttributes="True" />
-            </XmlFormattingPolicy>
-            <TextStylePolicy inheritsSet="null" scope="text/x-web" />
-          </Policies>
-        </Properties>
-      </MonoDevelop>
-    </ProjectExtensions>
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.9\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.9\build\Xamarin.Build.Download.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7A6574CB-A020-4BC5-82BA-BC8FB9022349}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>StarWarsSample.Droid</RootNamespace>
+    <AssemblyName>StarWarsSample.Droid</AssemblyName>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidApplication>True</AndroidApplication>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidTlsProvider>btls</AndroidTlsProvider>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="Mono.Android.Export" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
+    <PackageReference Include="OxyPlot.Xamarin.Android" Version="1.1.0-unstable0011" />
+    <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
+    <PackageReference Include="Acr.Support" Version="2.1.0" />
+    <PackageReference Include="Refractored.Controls.CircleImageView" Version="1.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="MvvmCross" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Droid.Support.Core.UI" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Droid.Support.Core.Utils" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Droid.Support.Design" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Droid.Support.Fragment" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Droid.Support.V7.RecyclerView" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
+    <PackageReference Include="Splat" Version="2.0.0" />
+    <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
+    <PackageReference Include="AndHUD" Version="1.2.0" />
+    <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0" />
+    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3" />
+    <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Annotations" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Compat" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Fragment" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Percent" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Transition" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Build.Download" Version="0.4.9" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Resources\Resource.designer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="LinkerPleaseInclude.cs" />
+    <Compile Include="Setup.cs" />
+    <Compile Include="SplashScreen.cs" />
+    <Compile Include="Views\MainView.cs" />
+    <Compile Include="Views\PlanetsView.cs" />
+    <Compile Include="Views\MenuView.cs" />
+    <Compile Include="Views\BaseFragment.cs" />
+    <Compile Include="Extensions\MvxRecyclerViewExtensions.cs" />
+    <Compile Include="Controls\RecyclerViewOnScrollListener.cs" />
+    <Compile Include="Views\PlanetView.cs" />
+    <Compile Include="Controls\InfoView.cs" />
+    <Compile Include="Views\PeopleView.cs" />
+    <Compile Include="Views\StatusView.cs" />
+    <Compile Include="Views\PersonView.cs" />
+    <Compile Include="MvxBindings\SwipeRefreshLayoutIsRefreshingTargetBinding.cs" />
+    <Compile Include="TemplateSelectors\PlanetsTemplateSelector.cs" />
+    <Compile Include="MainApplication.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AboutResources.txt" />
+    <None Include="Properties\AndroidManifest.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\MenuView.axml" />
+    <AndroidResource Include="Resources\values\Strings.xml" />
+    <AndroidResource Include="Resources\layout\MainView.axml" />
+    <AndroidResource Include="Resources\layout\SplashScreen.axml" />
+    <AndroidResource Include="Resources\layout\toolbar_actionbar.axml" />
+    <AndroidResource Include="Resources\values\colors.xml" />
+    <AndroidResource Include="Resources\values\dimens.xml" />
+    <AndroidResource Include="Resources\values\styles.xml" />
+    <AndroidResource Include="Resources\values-v21\styles.xml" />
+    <AndroidResource Include="Resources\menu\navigation_drawer.axml" />
+    <AndroidResource Include="Resources\layout\navigation_header.axml" />
+    <AndroidResource Include="Resources\layout\PlanetsView.axml" />
+    <AndroidResource Include="Resources\layout\item_name.axml" />
+    <AndroidResource Include="Resources\layout\PlanetView.axml" />
+    <AndroidResource Include="Resources\layout\control_info_view.axml" />
+    <AndroidResource Include="Resources\anim\pulse_animation.xml" />
+    <AndroidResource Include="Resources\layout\PeopleView.axml" />
+    <AndroidResource Include="Resources\drawable-nodpi\Planet_Header.jpg" />
+    <AndroidResource Include="Resources\drawable-nodpi\Background.jpg" />
+    <AndroidResource Include="Resources\mipmap-hdpi\icon.png" />
+    <AndroidResource Include="Resources\mipmap-mdpi\icon.png" />
+    <AndroidResource Include="Resources\mipmap-xhdpi\icon.png" />
+    <AndroidResource Include="Resources\mipmap-xxhdpi\icon.png" />
+    <AndroidResource Include="Resources\mipmap-xxxhdpi\icon.png" />
+    <AndroidResource Include="Resources\drawable\another_option.xml" />
+    <AndroidResource Include="Resources\drawable\people.xml" />
+    <AndroidResource Include="Resources\drawable\planet.xml" />
+    <AndroidResource Include="Resources\layout\StatusView.axml" />
+    <AndroidResource Include="Resources\drawable-hdpi\screen.png" />
+    <AndroidResource Include="Resources\drawable-mdpi\screen.png" />
+    <AndroidResource Include="Resources\drawable-xhdpi\screen.png" />
+    <AndroidResource Include="Resources\drawable-xxhdpi\screen.png" />
+    <AndroidResource Include="Resources\drawable-xxxhdpi\screen.png" />
+    <AndroidResource Include="Resources\drawable-nodpi\menu_header_background.png" />
+    <AndroidResource Include="Resources\drawable-nodpi\People_Header.png" />
+    <AndroidResource Include="Resources\drawable-nodpi\profile.png" />
+    <AndroidResource Include="Resources\drawable\statistics.xml" />
+    <AndroidResource Include="Resources\layout\PersonView.axml" />
+    <AndroidResource Include="Resources\layout\item_name_white.axml" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <AndroidAsset Include="Assets\starwars.json" />
+    <AndroidAsset Include="Assets\imgs\img_0.png" />
+    <AndroidAsset Include="Assets\imgs\img_1.png" />
+    <AndroidAsset Include="Assets\imgs\char1.png" />
+    <AndroidAsset Include="Assets\imgs\char2.png" />
+    <AndroidAsset Include="Assets\imgs\weapon.png" />
+    <AndroidAsset Include="Assets\imgs\weapon2.png" />
+    <AndroidAsset Include="Assets\starwars2.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\StarWarsSample.Core\StarWarsSample.Core.csproj">
+      <Project>{C8D72805-91D3-48B5-8F5B-44B9263198B6}</Project>
+      <Name>StarWarsSample.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy TabWidth="4" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabsToSpaces="True" scope="application/android+xml" />
+          <XmlFormattingPolicy scope="application/android+xml">
+            <DefaultFormat AttributesInNewLine="True" AlignAttributes="True" />
+          </XmlFormattingPolicy>
+          <TextStylePolicy inheritsSet="null" scope="text/x-web" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
 </Project>

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
-    <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
+    <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.4" />
     <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.0.3.1" />

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -51,10 +51,11 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Acr.UserDialogs">
+      <Version>7.0.1</Version>
+    </PackageReference>
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
     <PackageReference Include="OxyPlot.Xamarin.Android" Version="1.1.0-unstable0011" />
-    <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
-    <PackageReference Include="Acr.Support" Version="2.1.0" />
     <PackageReference Include="Refractored.Controls.CircleImageView" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="MvvmCross" Version="6.1.2" />
@@ -70,7 +71,6 @@
     <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
     <PackageReference Include="Splat" Version="2.0.0" />
     <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
-    <PackageReference Include="AndHUD" Version="1.2.0" />
     <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.0.3" />

--- a/StarWarsSample/StarWarsSample.Droid/Views/BaseFragment.cs
+++ b/StarWarsSample/StarWarsSample.Droid/Views/BaseFragment.cs
@@ -22,11 +22,6 @@ namespace StarWarsSample.Droid.Views
             }
         }
 
-        protected BaseFragment()
-        {
-            RetainInstance = true;
-        }
-
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             var ignore = base.OnCreateView(inflater, container, savedInstanceState);

--- a/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
@@ -237,10 +237,11 @@
     <BundleResource Include="Resources\profile.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Acr.UserDialogs">
+      <Version>7.0.1</Version>
+    </PackageReference>
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
     <PackageReference Include="OxyPlot.Xamarin.iOS" Version="1.1.0-unstable0011" />
-    <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
-    <PackageReference Include="Acr.Support" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="MvvmCross" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
@@ -250,7 +251,6 @@
     <PackageReference Include="Splat" Version="2.0.0" />
     <PackageReference Include="Cirrious.FluentLayout" Version="2.6.0" />
     <PackageReference Include="Com.Airbnb.iOS.Lottie" Version="2.1.5.0" />
-    <PackageReference Include="BTProgressHUD" Version="1.2.0.5" />
     <PackageReference Include="TZStackView" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
@@ -248,9 +248,13 @@
     <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
-    <PackageReference Include="Cirrious.FluentLayout" Version="2.6.0" />
-    <PackageReference Include="Com.Airbnb.iOS.Lottie" Version="2.1.5.0" />
     <PackageReference Include="TZStackView" Version="1.1.1" />
+    <PackageReference Include="Com.Airbnb.iOS.Lottie">
+      <Version>2.5.4</Version>
+    </PackageReference>
+    <PackageReference Include="Cirrious.FluentLayout">
+      <Version>2.7.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StarWarsSample.Core\StarWarsSample.Core.csproj">

--- a/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
@@ -1,288 +1,269 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build"
-         ToolsVersion="4.0"
-         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{4F3928A0-0F5C-496C-806A-09FD5C1975C8}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>StarWarsSample.iOS</RootNamespace>
+    <AssemblyName>StarWarsSample.iOS</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <IOSDebuggerPort>24235</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <IOSDebuggerPort>28295</IOSDebuggerPort>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_people.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_menu.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-small.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-small%402x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-small%403x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-40%402x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon%402x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-60%402x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-60%403x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-40.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-76.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-76%402x.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-167.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-750%402x~iphone6-portrait_750x1334.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-568h%402x~iphone_640x1136.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Portrait~ipad_768x1024.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Portrait%402x~ipad_1536x2048.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Landscape~ipad_1024x768.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Landscape%402x~ipad_2048x1536.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default%402x~iphone_640x960.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_people.imageset\people.pdf">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_planets.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_menu.imageset\menu.pdf">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_statistics.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_statistics.imageset\estadisticas.pdf">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_another_option.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_another_option.imageset\anotheroption1.pdf">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\ic_planets.imageset\planet.pdf">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\splash1242x2208.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\splash2208x1242.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\splash2048x2732.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="Setup.cs" />
+    <Compile Include="Views\MainView.cs" />
+    <Compile Include="Views\PeopleView.cs" />
+    <Compile Include="Views\PlanetsView.cs" />
+    <Compile Include="Views\MenuView.cs" />
+    <Compile Include="Sources\PeopleTableViewSource.cs" />
+    <Compile Include="Views\Cells\NameTableViewCell.cs" />
+    <Compile Include="Views\Cells\BaseTableViewCell.cs" />
+    <Compile Include="MvxBindings\NetworkIndicatorTargetBinding.cs" />
+    <Compile Include="Views\PersonView.cs" />
+    <Compile Include="CustomControls\TwitterCoverImageView.cs" />
+    <Compile Include="Sources\PlanetsTableViewSource.cs" />
+    <Compile Include="Views\PlanetView.cs" />
+    <Compile Include="CustomControls\InfoView.cs" />
+    <Compile Include="CustomControls\BaseView.cs" />
+    <Compile Include="Extensions\UIViewExtensions.cs" />
+    <Compile Include="Views\StatusView.cs" />
+    <Compile Include="CustomControls\MenuOption.cs" />
+    <Compile Include="LinkerPleaseInclude.cs" />
+    <Compile Include="Views\Cells\WhiteNameTableViewCell.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <BundleResource Include="Resources\starwars.json" />
+    <BundleResource Include="Resources\img_0.png" />
+    <BundleResource Include="Resources\img_1.png" />
+    <BundleResource Include="Resources\char1.png" />
+    <BundleResource Include="Resources\char2.png" />
+    <BundleResource Include="Resources\starwars2.json" />
+    <BundleResource Include="Resources\weapon.png" />
+    <BundleResource Include="Resources\weapon2.png" />
+    <BundleResource Include="Resources\Planet_Header.jpg" />
+    <BundleResource Include="Resources\Background.jpg" />
+    <BundleResource Include="Resources\Person_Header.png" />
+    <BundleResource Include="Resources\menu_header_background.png" />
+    <BundleResource Include="Resources\profile.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
+    <PackageReference Include="OxyPlot.Xamarin.iOS" Version="1.1.0-unstable0011" />
+    <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
+    <PackageReference Include="Acr.Support" Version="2.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="MvvmCross" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
+    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
+    <PackageReference Include="Splat" Version="2.0.0" />
+    <PackageReference Include="Cirrious.FluentLayout" Version="2.6.0" />
+    <PackageReference Include="Com.Airbnb.iOS.Lottie" Version="2.1.5.0" />
+    <PackageReference Include="BTProgressHUD" Version="1.2.0.5" />
+    <PackageReference Include="TZStackView" Version="1.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\StarWarsSample.Core\StarWarsSample.Core.csproj">
+      <Project>{C8D72805-91D3-48B5-8F5B-44B9263198B6}</Project>
+      <Name>StarWarsSample.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
-        <ProjectGuid>{4F3928A0-0F5C-496C-806A-09FD5C1975C8}</ProjectGuid>
-        <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <OutputType>Exe</OutputType>
-        <RootNamespace>StarWarsSample.iOS</RootNamespace>
-        <AssemblyName>StarWarsSample.iOS</AssemblyName>
-        <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-        <NuGetPackageImportStamp>
-        </NuGetPackageImportStamp>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
-        <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <DeviceSpecificBuild>true</DeviceSpecificBuild>
-        <MtouchDebug>true</MtouchDebug>
-        <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
-        <MtouchFastDev>true</MtouchFastDev>
-        <IOSDebuggerPort>24235</IOSDebuggerPort>
-        <MtouchLink>None</MtouchLink>
-        <MtouchArch>i386, x86_64</MtouchArch>
-        <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-        <PlatformTarget>x86</PlatformTarget>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\iPhone\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <MtouchFloat32>true</MtouchFloat32>
-        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-        <MtouchLink>SdkOnly</MtouchLink>
-        <MtouchArch>ARMv7, ARM64</MtouchArch>
-        <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-        <PlatformTarget>x86</PlatformTarget>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <DeviceSpecificBuild>true</DeviceSpecificBuild>
-        <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
-        <MtouchLink>None</MtouchLink>
-        <MtouchArch>i386, x86_64</MtouchArch>
-        <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-        <PlatformTarget>x86</PlatformTarget>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\iPhone\Debug</OutputPath>
-        <DefineConstants>DEBUG;ENABLE_TEST_CLOUD;</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <DeviceSpecificBuild>true</DeviceSpecificBuild>
-        <MtouchDebug>true</MtouchDebug>
-        <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
-        <MtouchFastDev>true</MtouchFastDev>
-        <MtouchFloat32>true</MtouchFloat32>
-        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-        <IOSDebuggerPort>28295</IOSDebuggerPort>
-        <MtouchLink>SdkOnly</MtouchLink>
-        <MtouchArch>ARMv7, ARM64</MtouchArch>
-        <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-        <PlatformTarget>x86</PlatformTarget>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="System" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Core" />
-        <Reference Include="Xamarin.iOS" />
-    </ItemGroup>
-    <ItemGroup>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_people.imageset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_menu.imageset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-small.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-small%402x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-small%403x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-40%402x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon%402x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-60%402x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-60%403x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-40.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-76.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-76%402x.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-167.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-750%402x~iphone6-portrait_750x1334.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-568h%402x~iphone_640x1136.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Portrait~ipad_768x1024.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Portrait%402x~ipad_1536x2048.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Landscape~ipad_1024x768.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default-Landscape%402x~ipad_2048x1536.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Default%402x~iphone_640x960.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_people.imageset\people.pdf">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_planets.imageset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_menu.imageset\menu.pdf">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_statistics.imageset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_statistics.imageset\estadisticas.pdf">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_another_option.imageset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_another_option.imageset\anotheroption1.pdf">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\ic_planets.imageset\planet.pdf">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\splash1242x2208.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\splash2208x1242.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\splash2048x2732.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="Info.plist" />
-        <None Include="Entitlements.plist" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Main.cs" />
-        <Compile Include="AppDelegate.cs" />
-        <Compile Include="Setup.cs" />
-        <Compile Include="Views\MainView.cs" />
-        <Compile Include="Views\PeopleView.cs" />
-        <Compile Include="Views\PlanetsView.cs" />
-        <Compile Include="Views\MenuView.cs" />
-        <Compile Include="Sources\PeopleTableViewSource.cs" />
-        <Compile Include="Views\Cells\NameTableViewCell.cs" />
-        <Compile Include="Views\Cells\BaseTableViewCell.cs" />
-        <Compile Include="MvxBindings\NetworkIndicatorTargetBinding.cs" />
-        <Compile Include="Views\PersonView.cs" />
-        <Compile Include="CustomControls\TwitterCoverImageView.cs" />
-        <Compile Include="Sources\PlanetsTableViewSource.cs" />
-        <Compile Include="Views\PlanetView.cs" />
-        <Compile Include="CustomControls\InfoView.cs" />
-        <Compile Include="CustomControls\BaseView.cs" />
-        <Compile Include="Extensions\UIViewExtensions.cs" />
-        <Compile Include="Views\StatusView.cs" />
-        <Compile Include="CustomControls\MenuOption.cs" />
-        <Compile Include="LinkerPleaseInclude.cs" />
-        <Compile Include="Views\Cells\WhiteNameTableViewCell.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <BundleResource Include="Resources\starwars.json" />
-        <BundleResource Include="Resources\img_0.png" />
-        <BundleResource Include="Resources\img_1.png" />
-        <BundleResource Include="Resources\char1.png" />
-        <BundleResource Include="Resources\char2.png" />
-        <BundleResource Include="Resources\starwars2.json" />
-        <BundleResource Include="Resources\weapon.png" />
-        <BundleResource Include="Resources\weapon2.png" />
-        <BundleResource Include="Resources\Planet_Header.jpg" />
-        <BundleResource Include="Resources\Background.jpg" />
-        <BundleResource Include="Resources\Person_Header.png" />
-        <BundleResource Include="Resources\menu_header_background.png" />
-        <BundleResource Include="Resources\profile.png" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="OxyPlot.Core"
-                          Version="2.0.0-unstable1035" />
-        <PackageReference Include="OxyPlot.Xamarin.iOS"
-                          Version="1.1.0-unstable0011" />
-        <PackageReference Include="Acr.UserDialogs"
-                          Version="6.5.1" />
-        <PackageReference Include="Acr.Support"
-                          Version="2.1.0" />
-        <PackageReference Include="Newtonsoft.Json"
-                          Version="11.0.2" />
-        <PackageReference Include="MvvmCross"
-                          Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Json"
-                          Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Color"
-                          Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Messenger"
-                          Version="6.0.0" />
-        <PackageReference Include="MvvmCross.Plugin.Visibility"
-                          Version="6.0.0" />
-        <PackageReference Include="Splat"
-                          Version="2.0.0" />
-        <PackageReference Include="Cirrious.FluentLayout"
-                          Version="2.6.0" />
-        <PackageReference Include="Com.Airbnb.iOS.Lottie"
-                          Version="2.1.5.0" />
-        <PackageReference Include="BTProgressHUD"
-                          Version="1.2.0.5" />
-        <PackageReference Include="TZStackView"
-                          Version="1.1.1" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\StarWarsSample.Core\StarWarsSample.Core.csproj">
-            <Project>{C8D72805-91D3-48B5-8F5B-44B9263198B6}</Project>
-            <Name>StarWarsSample.Core</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-    <Import Project="..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets"
-            Condition="Exists('..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" />
-    <Target Name="EnsureNuGetPackageBuildImports"
-            BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-    </Target>
+  </Target>
 </Project>

--- a/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
@@ -248,7 +248,6 @@
     <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
     <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
-    <PackageReference Include="Splat" Version="2.0.0" />
     <PackageReference Include="Cirrious.FluentLayout" Version="2.6.0" />
     <PackageReference Include="Com.Airbnb.iOS.Lottie" Version="2.1.5.0" />
     <PackageReference Include="TZStackView" Version="1.1.1" />


### PR DESCRIPTION
Updates StarWars sample from MvvmCross 6.0.0 to 6.1.2.

- Updated the third party Android libraries.
- Fixed a bug in the sample where `RetainInstance = true` in every fragment causes frequent "Task has cancelled" crashes.
- Implemented logging for RestClient.

Changes have been tested on Android. There are 2 iOS specific libraries that still need to be updated. I haven't done so because I have no ability to compile/test Xamarin.iOS.