### PR TITLE
Star wars sample update to v.6.2.0

### DIFF
--- a/StarWarsSample/StarWarsSample.Core/App.cs
+++ b/StarWarsSample/StarWarsSample.Core/App.cs
@@ -19,7 +19,7 @@ namespace StarWarsSample.Core
                 .AsInterfaces()
                 .RegisterAsLazySingleton();
 
-            Mvx.RegisterSingleton<IUserDialogs>(() => UserDialogs.Instance);
+            Mvx.IoCProvider.RegisterSingleton<IUserDialogs>(() => UserDialogs.Instance);
 
             // register the appstart object
             RegisterCustomAppStart<AppStart>();

--- a/StarWarsSample/StarWarsSample.Core/AppStart.cs
+++ b/StarWarsSample/StarWarsSample.Core/AppStart.cs
@@ -1,4 +1,5 @@
-﻿using MvvmCross.Navigation;
+﻿using System.Threading.Tasks;
+using MvvmCross.Navigation;
 using MvvmCross.ViewModels;
 using StarWarsSample.Core.ViewModels;
 
@@ -11,9 +12,9 @@ namespace StarWarsSample.Core
         {
         }
 
-        protected override void NavigateToFirstViewModel(object hint = null)
+        protected override Task NavigateToFirstViewModel(object hint = null)
         {
-            NavigationService.Navigate<MainViewModel>();
+            return NavigationService.Navigate<MainViewModel>();
         }
     }
 }

--- a/StarWarsSample/StarWarsSample.Core/StarWarsSample.Core.csproj
+++ b/StarWarsSample/StarWarsSample.Core/StarWarsSample.Core.csproj
@@ -22,10 +22,10 @@
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="7.0.1" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
-    <PackageReference Include="MvvmCross" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
+    <PackageReference Include="MvvmCross" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.resx">

--- a/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Droid/StarWarsSample.Droid.csproj
@@ -58,17 +58,6 @@
     <PackageReference Include="OxyPlot.Xamarin.Android" Version="1.1.0-unstable0011" />
     <PackageReference Include="Refractored.Controls.CircleImageView" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="MvvmCross" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Droid.Support.Core.UI" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Droid.Support.Core.Utils" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Droid.Support.Design" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Droid.Support.Fragment" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Droid.Support.V7.RecyclerView" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
     <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.4" />
     <PackageReference Include="Xamarin.Android.Arch.Core.Common" Version="1.0.0.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Common" Version="1.0.3.1" />
@@ -87,6 +76,39 @@
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Build.Download" Version="0.4.11" />
+    <PackageReference Include="MvvmCross">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Core.UI">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Core.Utils">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Design">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Fragment">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.V7.RecyclerView">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Color">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Json">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Messenger">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Visibility">
+      <Version>6.2.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/Setup.cs
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/Setup.cs
@@ -7,11 +7,5 @@ namespace StarWarsSample.Forms.Droid
 {
     public class Setup : MvxFormsAndroidSetup<Core.App, App>
     {
-        protected override IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
-        {
-            var presenter = new MvxFormsPagePresenter(viewPresenter);
-            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(presenter);
-            return presenter;
-        }
     }
 }

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/Setup.cs
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/Setup.cs
@@ -11,7 +11,7 @@ namespace StarWarsSample.Forms.Droid
         {
             // workaround which should be removed when https://github.com/MvvmCross/MvvmCross/pull/2972 is released
             var presenter = base.CreateFormsPagePresenter(viewPresenter);
-            Mvx.RegisterSingleton<IMvxFormsPagePresenter>(presenter);
+            Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(presenter);
             return presenter;
         }
     }

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/Setup.cs
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/Setup.cs
@@ -9,8 +9,7 @@ namespace StarWarsSample.Forms.Droid
     {
         protected override IMvxFormsPagePresenter CreateFormsPagePresenter(IMvxFormsViewPresenter viewPresenter)
         {
-            // workaround which should be removed when https://github.com/MvvmCross/MvvmCross/pull/2972 is released
-            var presenter = base.CreateFormsPagePresenter(viewPresenter);
+            var presenter = new MvxFormsPagePresenter(viewPresenter);
             Mvx.IoCProvider.RegisterSingleton<IMvxFormsPagePresenter>(presenter);
             return presenter;
         }

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/SplashScreen.cs
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/SplashScreen.cs
@@ -1,4 +1,5 @@
-﻿using Android.App;
+﻿using System.Threading.Tasks;
+using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using MvvmCross.Forms.Platforms.Android.Views;
@@ -20,10 +21,10 @@ namespace StarWarsSample.Forms.Droid
         {
         }
 
-        protected override void RunAppStart(Bundle bundle)
+        protected override Task RunAppStartAsync(Bundle bundle)
         {
             StartActivity(typeof(RootActivity));
-            base.RunAppStart(bundle);
+            return Task.CompletedTask;
         }
     }
 }

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/StarWarsSample.Forms.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/StarWarsSample.Forms.Droid.csproj
@@ -53,33 +53,6 @@
     <PackageReference Include="Acr.UserDialogs">
       <Version>7.0.1</Version>
     </PackageReference>
-    <PackageReference Include="MvvmCross">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Droid.Support.Design">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Droid.Support.Fragment">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Forms">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.Json">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.JsonLocalization">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.Messenger">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.ResourceLoader">
-      <Version>6.1.2</Version>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>
     </PackageReference>
@@ -140,6 +113,33 @@
     </PackageReference>
     <PackageReference Include="OxyPlot.Xamarin.Forms">
       <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Forms">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Json">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.JsonLocalization">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Messenger">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.ResourceLoader">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Design">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Fragment">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat">
+      <Version>6.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.iOS/StarWarsSample.Forms.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.iOS/StarWarsSample.Forms.iOS.csproj
@@ -131,24 +131,6 @@
     <PackageReference Include="Acr.UserDialogs">
       <Version>7.0.1</Version>
     </PackageReference>
-    <PackageReference Include="MvvmCross">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Forms">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.Json">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.JsonLocalization">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.Messenger">
-      <Version>6.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmCross.Plugin.ResourceLoader">
-      <Version>6.1.2</Version>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>
     </PackageReference>
@@ -173,6 +155,24 @@
     </PackageReference>
     <PackageReference Include="OxyPlot.Xamarin.Forms">
       <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Forms">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Json">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.JsonLocalization">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Messenger">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.ResourceLoader">
+      <Version>6.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms/StarWarsSample.Forms.UI.csproj
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms/StarWarsSample.Forms.UI.csproj
@@ -5,12 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MvvmCross" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Forms" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.JsonLocalization" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.ResourceLoader" Version="6.1.2" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.3.840" />
     <PackageReference Include="Xamarin.FFImageLoading.Svg" Version="2.4.3.840" />
     <PackageReference Include="Xamarin.FFImageLoading.Svg.Forms" Version="2.4.3.840" />
@@ -19,6 +13,12 @@
     <PackageReference Include="Acr.UserDialogs" Version="7.0.1" />
     <PackageReference Include="Com.Airbnb.Xamarin.Forms.Lottie" Version="2.5.4" />
     <PackageReference Include="OxyPlot.Xamarin.Forms" Version="1.0.0" />
+    <PackageReference Include="MvvmCross" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Forms" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.JsonLocalization" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.2.0" />
+    <PackageReference Include="MvvmCross.Plugin.ResourceLoader" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.iOS/StarWarsSample.iOS.csproj
@@ -213,17 +213,27 @@
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1035" />
     <PackageReference Include="OxyPlot.Xamarin.iOS" Version="1.1.0-unstable0011" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="MvvmCross" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Color" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.1.2" />
-    <PackageReference Include="MvvmCross.Plugin.Visibility" Version="6.1.2" />
     <PackageReference Include="TZStackView" Version="1.1.1" />
     <PackageReference Include="Com.Airbnb.iOS.Lottie">
       <Version>2.5.4</Version>
     </PackageReference>
     <PackageReference Include="Cirrious.FluentLayout">
       <Version>2.7.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Color">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Json">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Messenger">
+      <Version>6.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Plugin.Visibility">
+      <Version>6.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Update MvvmCross and Plugins from 6.1.2 to 6.2.0.


Fix StarWarsSample.Forms.Android issue: app stuck on SplashScreen after update to v6.2.0. [#3104](https://github.com/MvvmCross/MvvmCross/issues/3104)