### PR TITLE
upgrade/iOSnDroid-MvvmCross7

### DIFF
--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/StarWarsSample.Forms.Droid.csproj
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.Android/StarWarsSample.Forms.Droid.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -15,8 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -51,97 +50,103 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.0.4</Version>
+      <Version>7.1.0.446</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.3</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.VectorDrawable.Animated">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Annotations">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.Annotation">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Compat">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.Core">
+      <Version>1.2.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Core.UI">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.UI">
+      <Version>1.0.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.Utils">
+      <Version>1.0.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Design">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.Google.Android.Material">
+      <Version>1.0.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Fragment">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.Fragment">
+      <Version>1.2.4.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Media.Compat">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.Media">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.AppCompat">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable">
-      <Version>28.0.0.1</Version>
+    <PackageReference Include="Xamarin.AndroidX.VectorDrawable">
+      <Version>1.1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Forms">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Svg">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Svg.Forms">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Transformations">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1039999" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Com.Airbnb.Xamarin.Forms.Lottie">
-      <Version>2.5.4</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="Com.Airbnb.Android.Lottie">
-      <Version>2.5.4</Version>
+      <Version>3.4.2</Version>
     </PackageReference>
     <PackageReference Include="OxyPlot.Xamarin.Forms">
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Forms">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.Json">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.JsonLocalization">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.Messenger">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.ResourceLoader">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Droid.Support.Design">
-      <Version>6.2.3</Version>
+      <Version>6.4.3</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Droid.Support.Fragment">
-      <Version>6.2.3</Version>
+      <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat">
-      <Version>6.2.3</Version>
+      <Version>6.4.2</Version>
     </PackageReference>
-  </ItemGroup>
+  <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.6.1" />  <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4">
+    <Version>1.0.0.1</Version>
+  </PackageReference>
+  <PackageReference Include="Xamarin.AndroidX.Browser">
+    <Version>1.2.0.1</Version>
+  </PackageReference>
+</ItemGroup>
   <ItemGroup>
     <Compile Include="LinkerPleaseInclude.cs" />
     <Compile Include="RootActivity.cs" />

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.iOS/StarWarsSample.Forms.iOS.csproj
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms.iOS/StarWarsSample.Forms.iOS.csproj
@@ -167,50 +167,50 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.0.4</Version>
+      <Version>7.1.0.446</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Forms">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Svg">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Svg.Forms">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading.Transformations">
-      <Version>2.4.3.840</Version>
+      <Version>2.4.11.982</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1039999" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Com.Airbnb.Xamarin.Forms.Lottie">
-      <Version>2.5.4</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="Com.Airbnb.iOS.Lottie">
-      <Version>2.5.4</Version>
+      <Version>2.5.11</Version>
     </PackageReference>
     <PackageReference Include="OxyPlot.Xamarin.Forms">
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Forms">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.Json">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.JsonLocalization">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.Messenger">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Plugin.ResourceLoader">
-      <Version>6.2.3</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms/StarWarsSample.Forms.UI.csproj
+++ b/StarWarsSample/StarWarsSample.Forms/StarWarsSample.Forms/StarWarsSample.Forms.UI.csproj
@@ -5,20 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.3.840" />
-    <PackageReference Include="Xamarin.FFImageLoading.Svg" Version="2.4.3.840" />
-    <PackageReference Include="Xamarin.FFImageLoading.Svg.Forms" Version="2.4.3.840" />
-    <PackageReference Include="Xamarin.FFImageLoading.Transformations" Version="2.4.3.840" />
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1039999" />
-    <PackageReference Include="Acr.UserDialogs" Version="7.0.4" />
-    <PackageReference Include="Com.Airbnb.Xamarin.Forms.Lottie" Version="2.5.4" />
+    <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
+    <PackageReference Include="Xamarin.FFImageLoading.Svg" Version="2.4.11.982" />
+    <PackageReference Include="Xamarin.FFImageLoading.Svg.Forms" Version="2.4.11.982" />
+    <PackageReference Include="Xamarin.FFImageLoading.Transformations" Version="2.4.11.982" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
+    <PackageReference Include="Acr.UserDialogs" Version="7.1.0.446" />
+    <PackageReference Include="Com.Airbnb.Xamarin.Forms.Lottie" Version="3.1.2" />
     <PackageReference Include="OxyPlot.Xamarin.Forms" Version="1.0.0" />
-    <PackageReference Include="MvvmCross" Version="6.2.3" />
-    <PackageReference Include="MvvmCross.Forms" Version="6.2.3" />
-    <PackageReference Include="MvvmCross.Plugin.Json" Version="6.2.3" />
-    <PackageReference Include="MvvmCross.Plugin.JsonLocalization" Version="6.2.3" />
-    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="6.2.3" />
-    <PackageReference Include="MvvmCross.Plugin.ResourceLoader" Version="6.2.3" />
+    <PackageReference Include="MvvmCross" Version="7.0.0" />
+    <PackageReference Include="MvvmCross.Forms" Version="7.0.0" />
+    <PackageReference Include="MvvmCross.Plugin.Json" Version="7.0.0" />
+    <PackageReference Include="MvvmCross.Plugin.JsonLocalization" Version="7.0.0" />
+    <PackageReference Include="MvvmCross.Plugin.Messenger" Version="7.0.0" />
+    <PackageReference Include="MvvmCross.Plugin.ResourceLoader" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Migrated to AndroidX by Right clicking on the Android project and selecting "Migrate to AndroidX"
* Then updated all the nuget packages by right click on the Packages folder in the Solution explorer-> Update
* Upon building, it told me I was missing another Nuget package Xamarin.AndroidX.Legacy.Support.V4 and Xamarin.AndroidX.Browser, so I added those two as well
* The latest version of the Lottie package doesnt support a target framework less than Android 10, so I had to increase the target framework of the Android project

**Testing**
----------
* Tested on an Android 10 device and the Forms app built
* Tested on iPhone 8 simulator and it worked

**Notes**
----
* Tried to update the Traditional/Native Android project as well, but I got this error "Views/PersonView.cs(55,50,55,61): error CS7069: Reference to type 'MvxColor' claims it is defined in 'MvvmCross', but it could not be found"
* Also had issues updating the TipCalc sample
* Did not test UWP