### PR TITLE
upgrades/TipCalc-MigrateToMvvmCross7

### DIFF
--- a/TipCalc/TipCalc.Core/TipCalc.Core.csproj
+++ b/TipCalc/TipCalc.Core/TipCalc.Core.csproj
@@ -4,6 +4,6 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MvvmCross" Version="6.2.2" />
+        <PackageReference Include="MvvmCross" Version="7.0.0" />
     </ItemGroup>
 </Project>

--- a/TipCalc/TipCalc.Droid/Resources/layout/TipView.axml
+++ b/TipCalc/TipCalc.Droid/Resources/layout/TipView.axml
@@ -3,7 +3,7 @@
     xmlns:local="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:padding="20dp"
-    android:background="#00007f"
+    android:background="#888888"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <TextView

--- a/TipCalc/TipCalc.Droid/Resources/values/styles.xml
+++ b/TipCalc/TipCalc.Droid/Resources/values/styles.xml
@@ -1,8 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <resources>
-  <style name="Theme.Splash" parent="android:Theme">
-    <item name="android:windowBackground">@drawable/splash</item>
-    <item name="android:windowNoTitle">true</item>
-    <item name="android:windowFullscreen">true</item>
-  </style>
+	<style name="Theme.Splash" parent="AppTheme.Base">
+		<item name="android:statusBarColor">#000000</item>
+		<item name="android:windowNoTitle">true</item>
+		<item name="android:windowFullscreen">true</item>
+	</style>
+	<!-- Application theme -->
+	<style name="AppTheme" parent="AppTheme.Base">
+	</style>
+	<style name="AppTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
+		<item name="colorPrimary">#1a1a1a</item>
+		<item name="colorPrimaryDark">#000000</item>
+		<item name="colorAccent">#C1272C</item>
+		<item name="android:windowBackground">@android:color/white</item>
+	</style>
+	<style name="Toolbar">
+		<item name="android:layout_height">?attr/actionBarSize</item>
+		<item name="android:background">?attr/colorPrimary</item>
+	</style>
 </resources>

--- a/TipCalc/TipCalc.Droid/TipCalc.Droid.csproj
+++ b/TipCalc/TipCalc.Droid/TipCalc.Droid.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -15,7 +15,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -47,7 +47,28 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <PackageReference Include="MvvmCross">
-      <Version>6.2.2</Version>
+      <Version>7.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Fragment">
+      <Version>6.4.2</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Design">
+      <Version>6.4.3</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat">
+      <Version>6.4.2</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Core.UI">
+      <Version>6.4.2</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.Core.Utils">
+      <Version>6.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmCross.Droid.Support.V7.RecyclerView">
+      <Version>6.4.2</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
+      <Version>2.2.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/TipCalc/TipCalc.Droid/Views/TipView.cs
+++ b/TipCalc/TipCalc.Droid/Views/TipView.cs
@@ -5,7 +5,7 @@ using TipCalc.Core.ViewModels;
 
 namespace TipCalc.UI.Droid.Views
 {
-    [Activity(Label = "Tip Calculator", MainLauncher = true)]
+    [Activity(Label = "Tip Calculator", MainLauncher = true, Theme = "@style/AppTheme")]
     public class TipView : MvxActivity<TipViewModel>
     {
         protected override void OnCreate(Bundle bundle)

--- a/TipCalc/TipCalc.Forms.Droid/Properties/AndroidManifest.xml
+++ b/TipCalc/TipCalc.Forms.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.mvvmcross.TipCalc_Forms">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 	<application android:label="TipCalc.Forms"></application>
 </manifest>

--- a/TipCalc/TipCalc.Forms.Droid/TipCalc.Forms.Droid.csproj
+++ b/TipCalc/TipCalc.Forms.Droid/TipCalc.Forms.Droid.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TipCalc.Forms.Droid</RootNamespace>
     <AssemblyName>TipCalc.Forms.Droid</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -43,44 +43,61 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
-    <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Annotations" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Compat" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Fragment" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Media.Compat" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Transition" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.v7.Palette" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.AndroidX.VectorDrawable.Animated" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.UI" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.Utils" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.1-rc3" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.2.4.1" />
+    <PackageReference Include="Xamarin.AndroidX.Media" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Transition" Version="1.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.VectorDrawable" Version="1.1.0.1" />
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.6.0.800</Version>
+      <Version>4.8.0.1269</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
-      <Version>6.4.2</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross.Forms">
-      <Version>6.4.2</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.DrawerLayout">
-      <Version>28.0.0.3</Version>
+    <PackageReference Include="Xamarin.AndroidX.DrawerLayout">
+      <Version>1.0.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.ViewPager">
-      <Version>28.0.0.3</Version>
+    <PackageReference Include="Xamarin.AndroidX.ViewPager">
+      <Version>1.0.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.SwipeRefreshLayout">
-      <Version>28.0.0.3</Version>
+    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout">
+      <Version>1.0.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.CoordinaterLayout">
-      <Version>28.0.0.3</Version>
+    <PackageReference Include="Xamarin.AndroidX.CoordinatorLayout">
+      <Version>1.1.0.1</Version>
     </PackageReference>
-  </ItemGroup>
+  <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.6.1" />  <PackageReference Include="Xamarin.AndroidX.Browser">
+    <Version>1.2.0.1</Version>
+  </PackageReference>
+  <PackageReference Include="Xamarin.AndroidX.Core">
+    <Version>1.2.0.1</Version>
+  </PackageReference>
+  <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
+    <Version>2.2.0.1</Version>
+  </PackageReference>
+  <PackageReference Include="MvvmCross.Droid.Support.Fragment">
+    <Version>6.4.2</Version>
+  </PackageReference>
+  <PackageReference Include="MvvmCross.Droid.Support.Design">
+    <Version>6.4.3</Version>
+  </PackageReference>
+  <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat">
+    <Version>6.4.2</Version>
+  </PackageReference>
+</ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />

--- a/TipCalc/TipCalc.Forms.UI/Pages/TipView.xaml
+++ b/TipCalc/TipCalc.Forms.UI/Pages/TipView.xaml
@@ -15,6 +15,7 @@
                 <Label Text="Generosity" />
                 <Slider x:Name="GenerositySlider"
                         Maximum="100"
+                        BackgroundColor="Aqua"
                         mvx:Bi.nd="Value Generosity, Mode=TwoWay"/>
                 <Label Text="Tip to leave" />
                 <Label x:Name="TipLabel" 

--- a/TipCalc/TipCalc.Forms.UI/TipCalc.Forms.UI.csproj
+++ b/TipCalc/TipCalc.Forms.UI/TipCalc.Forms.UI.csproj
@@ -4,9 +4,9 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MvvmCross" Version="6.4.2" />
-        <PackageReference Include="MvvmCross.Forms" Version="6.4.2" />
-        <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
+        <PackageReference Include="MvvmCross" Version="7.0.0" />
+        <PackageReference Include="MvvmCross.Forms" Version="7.0.0" />
+        <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\TipCalc.Core\TipCalc.Core.csproj" />

--- a/TipCalc/TipCalc.Forms.iOS/TipCalc.Forms.iOS.csproj
+++ b/TipCalc/TipCalc.Forms.iOS/TipCalc.Forms.iOS.csproj
@@ -93,13 +93,13 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <PackageReference Include="MvvmCross.Forms">
-      <Version>6.4.2</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.6.0.800</Version>
+      <Version>4.8.0.1269</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
-      <Version>6.4.2</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/TipCalc/TipCalc.iOS/TipCalc.iOS.csproj
+++ b/TipCalc/TipCalc.iOS/TipCalc.iOS.csproj
@@ -75,7 +75,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <PackageReference Include="MvvmCross">
-      <Version>6.2.2</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* Upgraded the iOS and Android, Forms and Native apps to use the latest MvvmCross 7 package
* Due to an error, had to increase minimum API version to 19 for Android
* Updated the Target android framework to Android 10, to avoid errors
* Migrated to AndroidX using the VS for Mac tool (right click on Android project and select Migrate to AndroidX)
* Then updated all the nuget packages by right clicking on the packages folder and selecting "Update" for all 3 projects
* Changed the background color of the slider in the Forms project, to make it more visible on Android
* Changed the background color of the page in the Android native project to grey, to make it less despicable
* On Android native, added themes because we were getting an error demanding AppCompat themes from the Activities

**Testing**
-------------
* Tested the iOS forms and native projects on an iOS Simulator running iOS 13.5 on iPhone8
* Tested the Android forms and native projects on Android device running Android 10 on a Xiaomi Redmi 8